### PR TITLE
Copy screenshots to allure folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ examples/base-implementation/allure/*
 *.tgz
 
 docs/.vuepress/dist
+
+.idea

--- a/src/reporter/allure-reporter.ts
+++ b/src/reporter/allure-reporter.ts
@@ -11,6 +11,7 @@ import {
   Stage,
   Status,
 } from 'allure-js-commons';
+import * as fs from 'fs';
 import { ErrorObject, Screenshot, TestRunInfo } from '../testcafe/models';
 import { TestStep } from '../testcafe/step';
 import { loadCategoriesConfig, loadReporterConfig } from '../utils/config';
@@ -208,7 +209,7 @@ export default class AllureReporter {
   }
 
   private addScreenshotAttachment(test: ExecutableItemWrapper, screenshot: Screenshot): void {
-    if (screenshot.screenshotPath) {
+    if (screenshot.screenshotPath && fs.existsSync(screenshot.screenshotPath)) {
       let screenshotName: string;
       if (screenshot.takenOnFail) {
         screenshotName = reporterConfig.LABEL.SCREENSHOT_ON_FAIL;
@@ -221,7 +222,10 @@ export default class AllureReporter {
         screenshotName = `${screenshotName} - ${screenshot.userAgent}`;
       }
 
-      test.addAttachment(screenshotName, ContentType.PNG, screenshot.screenshotPath);
+      const img = fs.readFileSync(screenshot.screenshotPath);
+
+      const file = this.runtime.writeAttachment(img, ContentType.PNG);
+      test.addAttachment(screenshotName, ContentType.PNG, file);
     }
   }
 

--- a/tests/unit/reporter/allure-reporter.spec.ts
+++ b/tests/unit/reporter/allure-reporter.spec.ts
@@ -137,7 +137,6 @@ jest.mock('../../../src/testcafe/step', () => {
     }),
   };
 });
-jest.mock('fs');
 
 describe('Allure reporter - Instancing', () => {
   beforeEach(() => {

--- a/tests/unit/reporter/allure-reporter.spec.ts
+++ b/tests/unit/reporter/allure-reporter.spec.ts
@@ -10,6 +10,7 @@ import {
   Stage,
   Status,
 } from 'allure-js-commons';
+import * as fs from 'fs';
 import AllureReporter from '../../../src/reporter/allure-reporter';
 import Metadata from '../../../src/reporter/metadata';
 import { Screenshot, TestRunInfo } from '../../../src/testcafe/models';
@@ -40,6 +41,7 @@ const mockRuntimeStartGroup = jest.fn().mockImplementation((name) => name);
 const mockRuntimeEndGroup = jest.fn().mockImplementation((name) => name);
 const mockRuntimeWriteCategoriesDefinitions = jest.fn();
 const mockRuntimewriteEnvironmentInfo = jest.fn();
+const mockRuntimeWriteAttachment = jest.fn().mockImplementation(() => 'filename.png');
 const mockAddMetadataToTest = jest.fn();
 const mockTestStepMergeOnSameName = jest.fn();
 const mockMergeSteps = jest.fn().mockImplementation((steps) => {
@@ -83,6 +85,7 @@ jest.mock('allure-js-commons', () => {
         endGroup: mockRuntimeEndGroup,
         writeCategoriesDefinitions: mockRuntimeWriteCategoriesDefinitions,
         writeEnvironmentInfo: mockRuntimewriteEnvironmentInfo,
+        writeAttachment: mockRuntimeWriteAttachment,
       };
     }),
     AllureGroup: jest.fn().mockImplementation(() => {
@@ -134,6 +137,7 @@ jest.mock('../../../src/testcafe/step', () => {
     }),
   };
 });
+jest.mock('fs');
 
 describe('Allure reporter - Instancing', () => {
   beforeEach(() => {
@@ -443,6 +447,9 @@ describe('Allure reporter - Helper Functions', () => {
   });
 
   it('Should add screenshots to an ended test without steps', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+
     const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
     const testScreenshotOnFail: Screenshot = { screenshotPath: 'testPathOnFail', takenOnFail: true };
     const testScreenshots: Screenshot[] = [testScreenshotManual, testScreenshotOnFail];
@@ -452,16 +459,8 @@ describe('Allure reporter - Helper Functions', () => {
     reporter.addScreenshotAttachments(mockAllureTest, testRunInfo);
 
     expect(mockTestAddAttachment).toBeCalledTimes(2);
-    expect(mockTestAddAttachment).toBeCalledWith(
-      'Screenshot taken manually',
-      ContentType.PNG,
-      testScreenshotManual.screenshotPath,
-    );
-    expect(mockTestAddAttachment).toBeCalledWith(
-      'Screenshot taken on fail',
-      ContentType.PNG,
-      testScreenshotOnFail.screenshotPath,
-    );
+    expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken manually', ContentType.PNG, 'filename.png');
+    expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken on fail', ContentType.PNG, 'filename.png');
   });
   it('Should add screenshots to an ended test with steps', () => {
     const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };


### PR DESCRIPTION
### Issue

When using the reporter the generated report contains relative references to screenshots. In some cases this can be an issue, for example when it is run in a docker container using volume mounts or in a ci environment (bitbucket pipelines) where only the allure reports folder is archived.
How does it look in an example allure result json:
```
...
  "attachments": [
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "/opt/testcafe/docker/testcafe/screenshots/baseline/inputfield/Input field_Chrome_Linux.png"
    },
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "/opt/testcafe/docker/testcafe/screenshots/actual/inputfield/Input field_Chrome_Linux_1.png"
    },
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "/opt/testcafe/docker/testcafe/screenshots/diff/inputfield/Input field_Chrome_Linux_1.png"
    }
  ],
 ...
```

### Description of the Change

The change I made is that the screenshots will first be copied to the allure report folder before they are attached to the report. Then the screenshots always reside in the same folder as the generated report.
It is inspired by the `writeAttachment` method used in the example reporters in the `allure-js` package. For example the [mocha reporter](https://github.com/allure-framework/allure-js/blob/f4e2e4ddfe1ffe204bed22fb5c3bf36d15e0d282/packages/allure-mocha/src/AllureReporter.ts). Here the `allureRuntime.writeAttachment` function is used to copy the attachment the report folder before calling the `addAttachment`.

How does it look in an example allure result json:
```
...
  "attachments": [
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "e9f362a3-0d5e-4265-857c-5912630c8842-attachment.png"
    },
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "25698b15-e9ad-4aef-83f2-0328d73bcfdc-attachment.png"
    },
    {
      "name": "Screenshot taken manually",
      "type": "image/png",
      "source": "6ab08c7c-ce39-4913-a485-102e62205010-attachment.png"
    }
  ],
...
```

### Possible Drawbacks

Can't think of any beside copying screenshots increases used disk space.

### Verification Process

The unit tests regarding this functionality are updated and passing.
I also performed tests using my own [testcafe docker repository](https://github.com/richardhendricksen/visual-regression-testcafe-in-docker) to confirm the desired changes.