### PR TITLE
fix(reporter): fix default detailsMessage and detailsTrace value

### DIFF
--- a/allure-categories.config.js
+++ b/allure-categories.config.js
@@ -1,0 +1,48 @@
+module.exports = [
+  // Default categories
+  {
+    name: 'Ignored tests',
+    matchedStatuses: ['skipped'],
+  },
+  {
+    name: 'Product defects',
+    matchedStatuses: ['failed'],
+    messageRegex: '.*Assertion failed.*',
+  },
+  {
+    name: 'Test defects',
+    matchedStatuses: ['failed'],
+  },
+  {
+    name: 'Warnings',
+    matchedStatuses: ['passed'],
+    messageRegex: '.*Warning.*',
+  },
+  {
+    name: 'Flaky tests',
+    matchedStatuses: ['passed', 'failed'],
+    messageRegex: '.*Flaky.*',
+  },
+
+  // Custom categories
+  // https://github.com/isaaceindhoven/testcafe-reporter-allure/issues/45
+  {
+    name: 'Selector Not Found',
+    traceRegex: '.*selector does not match any.*',
+  },
+  {
+    name: 'Setup Errors',
+    messageRegex: '.*Error in (fixture|test).before(Each)? hook.*',
+  },
+  { name: 'Assertion Errors', messageRegex: '.*AssertionError:.*' },
+  { name: 'Role Errors', messageRegex: '.*Error in Role initializer.*' },
+  {
+    name: 'Type Errors',
+    messageRegex: '.*TypeError: Cannot read property.*',
+  },
+  {
+    name: 'Client Function Errors',
+    messageRegex: '.*An error occurred in ClientFunction code.*',
+  },
+  { name: 'Ignored tests', matchedStatuses: ['skipped'] },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,19 +3761,19 @@
       "dev": true
     },
     "allure-js-commons": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-2.0.0-beta.7.tgz",
-      "integrity": "sha512-mTHr1RntyvxXXaqdj94DqtanVUozKXQVNOhuKwqOvbPHKRUd6DIeW0WjPXCTag4NE/jx/FO/MVPErYutbGwOUA==",
+      "version": "2.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-2.0.0-beta.8.tgz",
+      "integrity": "sha512-4u4GUKgGgKIRn/W41SJprXwVBO6MydDQVbwdR12nKkS34rj0oac2D8LjKcLnvRXRw2fr9fFnBoCGqtag3nnZIA==",
       "requires": {
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^1.0.4",
         "properties": "^1.2.1",
-        "uuid": "^7.0.2"
+        "uuid": "^8.3.0"
       },
       "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },
@@ -13110,7 +13110,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -13186,6 +13187,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "allure-js-commons": "^2.0.0-beta.6",
+    "allure-js-commons": "^2.0.0-beta.8",
     "merge-anything": "^3.0.3",
     "rimraf": "^3.0.2",
     "uuid": "^8.3.1"

--- a/src/reporter/allure-reporter.ts
+++ b/src/reporter/allure-reporter.ts
@@ -98,8 +98,8 @@ export default class AllureReporter {
     const hasWarnings = !!testRunInfo.warnings && !!testRunInfo.warnings.length;
     const isSkipped = testRunInfo.skipped;
 
-    let testMessages: string = null;
-    let testDetails: string = null;
+    let testMessages: string = '';
+    let testDetails: string = '';
 
     if (isSkipped) {
       currentTest.status = Status.SKIPPED;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,5 @@
 export default function addNewLine(text: string, line: string): string {
-  if (text === null) {
+  if (text === null || text.length === 0) {
     return line;
   }
   return `${text}\n${line}`;

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,6 +1,10 @@
 import { Selector } from 'testcafe';
 import { Severity, step } from '../../src/utils';
 
+const TIER2 = { tier2: 'true' };
+const SMOKE = { type: 'smoke' };
+const OWNERS = { owner: 'team' };
+
 fixture('TestCafé Example Fixture - Main').page('http://devexpress.github.io/testcafe/example').meta({
   epic: 'Example Epic Ticket',
   suite: 'Example Fixture Group',
@@ -120,3 +124,104 @@ test.meta({
     .expect(Selector('#article-header').innerText)
     .eql('Thank you, John Smith!');
 });
+
+fixture.meta(OWNERS);
+
+[...Array(2).keys()].forEach((testNumber) => {
+  test.meta(SMOKE).meta(TIER2).meta({
+    suite: 'big suite',
+    epic: 'big epic',
+    story: 'big story',
+    feature: 'big feature',
+    description: 'Checks something else',
+  })(`Passing Test ${testNumber}`, async () => {});
+
+  test.meta(SMOKE).meta(TIER2).meta({
+    severity: 'critical',
+    story: 'As user I want to be able to do...',
+    description: 'Checks something',
+  })(`Passing Test With ALL META ${testNumber}`, async () => {});
+});
+
+test.meta(SMOKE).meta(TIER2).page('https://getbootstrap.com/docs/4.1/components/alerts/')(
+  'Passing Test with 2 screenshots',
+  async (t) => {
+    await t.takeScreenshot();
+    await t.takeElementScreenshot(Selector('.alert'));
+  },
+);
+
+fixture('All Skipped Fixture').meta(OWNERS);
+
+[...Array(2).keys()].forEach((testNumber) => {
+  test.skip.meta(SMOKE).meta(TIER2)(`Skipped Test ${testNumber}`, async () => {});
+});
+
+fixture('All Failed Fixture').meta(OWNERS);
+
+test.meta(SMOKE).meta(TIER2)('Failed Test 1 Incorrect Assert', async (t) => {
+  await t.expect(1).eql(0);
+});
+
+test.meta(SMOKE).meta(TIER2)('Failed Test 2', async (t) => {
+  await t.expect(Selector('body').find('foo').hasAttribute('bar')).ok();
+});
+
+test.meta(SMOKE).meta(TIER2)('Failed Test 3 No ', async () => {
+  const bar = {};
+  // @ts-ignore
+  bar.toString2();
+});
+
+test.meta(SMOKE).meta(TIER2).meta({
+  suite: 'big suite',
+  epic: 'big epic',
+  story: 'big story',
+  feature: 'big feature',
+})('Failed Test 4 Error Thrown', async () => {
+  throw new Error('Boo');
+});
+
+test.meta(SMOKE).meta(TIER2).page('https://getbootstrap.com/docs/4.1/components/alerts/')(
+  'Failed Test 4 Selector DNE with 2 screenshots',
+  async (t) => {
+    await t.takeScreenshot();
+    await t.takeElementScreenshot(Selector('.alert'));
+    await t.expect(Selector('body').find('bar').exists).ok();
+  },
+);
+
+test.meta(SMOKE).meta(TIER2).page('https://getbootstrap.com/docs/4.1/components/alerts/')(
+  'Failed Test 5 Selector Click DNE',
+  async (t) => {
+    await t.click(Selector('body').find('bar'));
+  },
+);
+
+fixture('Mixed Fixture').meta(OWNERS);
+
+test.skip.meta(SMOKE).meta(TIER2)('MF Skipped Test', async () => {});
+
+test.meta(SMOKE).meta(TIER2)('MF Failed Test Selector DNE', async (t) => {
+  await t.expect(Selector('bad').hasAttribute('bar')).ok();
+});
+
+[...Array(2).keys()].forEach((testNumber) => {
+  test.meta(SMOKE).meta(TIER2).meta({
+    severity: 'critical',
+    story: 'I am a user story',
+    description: 'Checks something foo',
+  })(`Pass/Fail Test With ALL META ${testNumber}`, async (t) => {
+    await t.expect(testNumber % 2).eql(0);
+  });
+});
+
+fixture.meta(OWNERS)`Failing Fixture Setup`.beforeEach(async (t) => {
+  await t.click(Selector('baz'));
+});
+test.meta(SMOKE).meta(TIER2)('FF Test', async () => {});
+
+fixture.meta(OWNERS)`Failing Assert Fixture`.beforeEach(async (t) => {
+  await t.expect(1).eql(0);
+});
+test.meta(SMOKE).meta(TIER2)('FAF Test', async () => {});

--- a/tests/unit/reporter/allure-reporter-merger.spec.ts
+++ b/tests/unit/reporter/allure-reporter-merger.spec.ts
@@ -26,7 +26,7 @@ describe('Allure reporter - Merge Functions', () => {
     expect(testStepTwo.screenshotAmount).toBe(2);
   });
 
-  it('Should not merge steps if they dont have the same name', () => {
+  it("Should not merge steps if they don't have the same name", () => {
     const reporter: AllureReporter = new AllureReporter();
     const testStepOne: TestStep = new TestStep('testStepOne', 1);
     const testStepTwo: TestStep = new TestStep('testStepTwo', 2);
@@ -61,7 +61,7 @@ describe('Allure reporter - Merge Functions', () => {
     expect(actualErrors).toStrictEqual(expectedErrors);
   });
 
-  it('Should not merge errors if they dont have the same message', () => {
+  it("Should not merge errors if they don't have the same message", () => {
     const reporter: AllureReporter = new AllureReporter();
 
     const errorOne: ErrorObject = { errMsg: 'errorOne', userAgent: 'chrome' };

--- a/tests/unit/reporter/allure-reporter.spec.ts
+++ b/tests/unit/reporter/allure-reporter.spec.ts
@@ -139,408 +139,419 @@ jest.mock('../../../src/testcafe/step', () => {
 });
 jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
 
-describe('Allure reporter - Instancing', () => {
+describe('Allure reporter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('Should instantiate an AllureRuntime if no custom config is given', () => {
-    const reporter: AllureReporter = new AllureReporter();
+  describe('Instancing', () => {
+    it('Should instantiate an AllureRuntime if no custom config is given', () => {
+      const reporter: AllureReporter = new AllureReporter();
 
-    expect(AllureConfig).toHaveBeenCalledTimes(1);
-    expect(AllureRuntime).toHaveBeenCalledTimes(1);
+      expect(AllureConfig).toHaveBeenCalledTimes(1);
+      expect(AllureRuntime).toHaveBeenCalledTimes(1);
 
-    // @ts-ignore
-    expect(reporter.runtime).toBeDefined();
+      // @ts-ignore
+      expect(reporter.runtime).toBeDefined();
+    });
+
+    it('Should instantiate an AllureRuntime with a custom AllureConfig', () => {
+      const allureConfig: AllureConfig = { resultsDir: 'test' };
+      const reporter: AllureReporter = new AllureReporter(allureConfig);
+
+      expect(AllureRuntime).toHaveBeenCalledTimes(1);
+      expect(AllureRuntime).toBeCalledWith(allureConfig);
+      expect(AllureConfig).not.toHaveBeenCalled();
+
+      // @ts-ignore
+      expect(reporter.runtime).toBeDefined();
+    });
+
+    it('Should write category globals to runtime if exists', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const categories = loadCategoriesConfig();
+
+      reporter.setGlobals();
+
+      expect(mockRuntimeWriteCategoriesDefinitions).toHaveBeenCalledTimes(1);
+      expect(mockRuntimeWriteCategoriesDefinitions).toBeCalledWith(categories);
+    });
+
+    it('Should write userAgent environment globals to runtime', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const userAgents = ['chrome'];
+      const userAgentsEnvironment = { browsers: userAgents.toString() };
+
+      // @ts-ignore
+      reporter.userAgents = ['chrome'];
+
+      reporter.setGlobals();
+
+      expect(mockRuntimewriteEnvironmentInfo).toHaveBeenCalledTimes(1);
+      expect(mockRuntimewriteEnvironmentInfo).toBeCalledWith(userAgentsEnvironment);
+    });
+
+    it('Should not write userAgent environment globals to runtime if null', () => {
+      const reporter: AllureReporter = new AllureReporter();
+
+      // @ts-ignore
+      reporter.userAgents = null;
+
+      reporter.setGlobals();
+
+      expect(mockRuntimewriteEnvironmentInfo).toHaveBeenCalledTimes(0);
+    });
   });
-  it('Should instantiate an AllureRuntime with a custom AllureConfig', () => {
-    const allureConfig: AllureConfig = { resultsDir: 'test' };
-    const reporter: AllureReporter = new AllureReporter(allureConfig);
 
-    expect(AllureRuntime).toHaveBeenCalledTimes(1);
-    expect(AllureRuntime).toBeCalledWith(allureConfig);
-    expect(AllureConfig).not.toHaveBeenCalled();
+  describe('Grouping', () => {
+    it('Should start group correctly', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const groupName: string = 'testGroup';
+      const groupMeta: object = { severity: Severity.TRIVIAL };
 
-    // @ts-ignore
-    expect(reporter.runtime).toBeDefined();
-  });
-  it('Should write category globals to runtime if exists', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const categories = loadCategoriesConfig();
+      reporter.startGroup(groupName, groupMeta);
 
-    reporter.setGlobals();
+      expect(Metadata).toHaveBeenCalledTimes(1);
+      expect(Metadata).toBeCalledWith(groupMeta);
+      // @ts-ignore
+      expect(reporter.groupMetadata).toBeDefined();
+      // @ts-ignore
+      expect(reporter.groupMetadata.severity).toBe(groupMeta.severity);
+      // @ts-ignore
+      expect(reporter.groupMetadata.suite).toBe(groupName);
+      expect(mockRuntimeStartGroup).toBeCalledWith(groupName);
+      // @ts-ignore
+      expect(reporter.group).toBeDefined();
+    });
 
-    expect(mockRuntimeWriteCategoriesDefinitions).toHaveBeenCalledTimes(1);
-    expect(mockRuntimeWriteCategoriesDefinitions).toBeCalledWith(categories);
-  });
-  it('Should write userAgent environment globals to runtime', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const userAgents = ['chrome'];
-    const userAgentsEnvironment = { browsers: userAgents.toString() };
+    it('Should end group correctly if one exists', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.group = new AllureGroup(null);
 
-    // @ts-ignore
-    reporter.userAgents = ['chrome'];
+      // @ts-ignore
+      expect(reporter.group).toBeDefined();
 
-    reporter.setGlobals();
+      reporter.endGroup();
 
-    expect(mockRuntimewriteEnvironmentInfo).toHaveBeenCalledTimes(1);
-    expect(mockRuntimewriteEnvironmentInfo).toBeCalledWith(userAgentsEnvironment);
-  });
-  it('Should not write userAgent environment globals to runtime if null', () => {
-    const reporter: AllureReporter = new AllureReporter();
+      expect(mockGroupEndGroup).toHaveBeenCalledTimes(1);
+    });
 
-    // @ts-ignore
-    reporter.userAgents = null;
+    it('Should start test if a group exists', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.group = new AllureGroup(null);
+      // @ts-ignore
+      reporter.setCurrentTest = mockReporterSetCurrentTest;
 
-    reporter.setGlobals();
-
-    expect(mockRuntimewriteEnvironmentInfo).toHaveBeenCalledTimes(0);
-  });
-});
-
-describe('Allure reporter - Grouping', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-  it('Should start group correctly', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const groupName: string = 'testGroup';
-    const groupMeta: object = { severity: Severity.TRIVIAL };
-
-    reporter.startGroup(groupName, groupMeta);
-
-    expect(Metadata).toHaveBeenCalledTimes(1);
-    expect(Metadata).toBeCalledWith(groupMeta);
-    // @ts-ignore
-    expect(reporter.groupMetadata).toBeDefined();
-    // @ts-ignore
-    expect(reporter.groupMetadata.severity).toBe(groupMeta.severity);
-    // @ts-ignore
-    expect(reporter.groupMetadata.suite).toBe(groupName);
-    expect(mockRuntimeStartGroup).toBeCalledWith(groupName);
-    // @ts-ignore
-    expect(reporter.group).toBeDefined();
-  });
-  it('Should end group correctly if one exists', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.group = new AllureGroup(null);
-
-    // @ts-ignore
-    expect(reporter.group).toBeDefined();
-
-    reporter.endGroup();
-
-    expect(mockGroupEndGroup).toHaveBeenCalledTimes(1);
-  });
-  it('Should start test if a group exists', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.group = new AllureGroup(null);
-    // @ts-ignore
-    reporter.setCurrentTest = mockReporterSetCurrentTest;
-
-    reporter.startTest(testName, testMeta);
-
-    expect(mockGroupStartTest).toHaveBeenCalledTimes(1);
-    expect(mockGroupStartTest).toBeCalledWith(testName);
-    expect(mockReporterSetCurrentTest).toHaveBeenCalledTimes(1);
-
-    expect(mockAllureTest.fullName).toBe(`${mockGroupName} : ${testName}`);
-    expect(mockAllureTest.historyId).toBe('00000000-0000-0000-0000-000000000000');
-    expect(mockAllureTest.stage).toBe(Stage.RUNNING);
-  });
-  it('Should not start test if no group exists', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.group = null;
-
-    expect(() => {
       reporter.startTest(testName, testMeta);
-    }).toThrow();
 
-    expect(mockGroupStartTest).not.toHaveBeenCalled();
-  });
-});
+      expect(mockGroupStartTest).toHaveBeenCalledTimes(1);
+      expect(mockGroupStartTest).toBeCalledWith(testName);
+      expect(mockReporterSetCurrentTest).toHaveBeenCalledTimes(1);
 
-describe('Allure reporter - Test Processing', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+      expect(mockAllureTest.fullName).toBe(`${mockGroupName} : ${testName}`);
+      expect(mockAllureTest.historyId).toBe('00000000-0000-0000-0000-000000000000');
+      expect(mockAllureTest.stage).toBe(Stage.RUNNING);
+    });
 
-  it('Should end passing test with no steps', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testRunInfo: TestRunInfo = {};
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-    // @ts-ignore
-    reporter.addScreenshotAttachments = mockReporterAddScreenshotAttachments;
+    it('Should not start test if no group exists', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.group = null;
 
-    reporter.endTest(testName, testRunInfo, testMeta);
+      expect(() => {
+        reporter.startTest(testName, testMeta);
+      }).toThrow();
 
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(Metadata).toHaveBeenCalledTimes(1);
-    expect(Metadata).toBeCalledWith(testMeta, true);
-    expect(mockAddMetadataToTest).toHaveBeenCalledTimes(1);
-    expect(mockGetSteps).toBeCalledTimes(1);
-    expect(mockReporterAddScreenshotAttachments).toBeCalledTimes(1);
-
-    expect(mockAllureTest.status).toBe(Status.PASSED);
-    expect(mockAllureTest.detailsMessage).toBe(null);
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should end passing test with steps', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testRunInfo: TestRunInfo = {};
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-    // @ts-ignore
-    reporter.addStepsWithAttachments = mockReporterAddStepsWithAttachments;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(Metadata).toHaveBeenCalledTimes(1);
-    expect(Metadata).toBeCalledWith(testMeta, true);
-    expect(mockAddMetadataToTest).toHaveBeenCalledTimes(1);
-    expect(mockGetSteps).toBeCalledTimes(1);
-    expect(mockReporterAddStepsWithAttachments).toBeCalledTimes(1);
-
-    expect(mockAllureTest.status).toBe(Status.PASSED);
-    expect(mockAllureTest.detailsMessage).toBe(null);
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should end skipped test', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testRunInfo: TestRunInfo = { skipped: true };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(mockAllureTest.status).toBe(Status.SKIPPED);
-    expect(mockAllureTest.detailsMessage).toBe(null);
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should add warnings to ended test', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testWarnings: string[] = ['warning1', 'warning2'];
-    const testRunInfo: TestRunInfo = { warnings: testWarnings };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(mockAllureTest.status).toBe(Status.PASSED);
-    expect(mockAllureTest.detailsMessage).toBe('warning1\nwarning2');
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should add errors to ended test', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testError: any = {
-      callsite: {
-        filename: 'testFilename',
-        lineNum: 'testLineNum',
-      },
-      userAgent: 'testUserAgent',
-      errMsg: 'testErrorMessage',
-    };
-    const testErrors: any[] = [testError];
-    const testRunInfo: TestRunInfo = { errs: testErrors };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(mockAllureTest.status).toBe(Status.FAILED);
-    expect(mockAllureTest.detailsMessage).toBe(testError.errMsg);
-    expect(mockAllureTest.detailsTrace).toBe(
-      `File name: ${testError.callsite.filename}\nLine number: ${testError.callsite.lineNum}\nUser Agent(s): ${testError.userAgent}`,
-    );
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should not add empty errors to ended test', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testError: any = { callsite: {} };
-    const testErrors: any[] = [testError];
-    const testRunInfo: TestRunInfo = { errs: testErrors };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(mockAllureTest.status).toBe(Status.FAILED);
-    expect(mockAllureTest.detailsMessage).toBe(null);
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should not add empty callsite errors to ended test', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testError: any = {};
-    const testErrors: any[] = [testError];
-    const testRunInfo: TestRunInfo = { errs: testErrors };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestExists;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
-    expect(mockAllureTest.status).toBe(Status.FAILED);
-    expect(mockAllureTest.detailsMessage).toBe(null);
-    expect(mockAllureTest.detailsTrace).toBe(null);
-    expect(mockAllureTest.stage).toBe(Stage.FINISHED);
-    expect(mockTestEndTest).toBeCalledTimes(1);
-  });
-  it('Should start new test if non-existing test is ended', () => {
-    const testName: string = 'testname';
-    const testMeta: object = { severity: Severity.TRIVIAL };
-    const testRunInfo: TestRunInfo = {};
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.getCurrentTest = mockReporterGetCurrentTestNull;
-    // @ts-ignore
-    reporter.startTest = mockReporterStartTest;
-
-    reporter.endTest(testName, testRunInfo, testMeta);
-
-    expect(mockReporterGetCurrentTestNull).toBeCalledTimes(2);
-    expect(mockReporterStartTest).toBeCalledTimes(1);
-    expect(mockReporterStartTest).toBeCalledWith(testName, testMeta);
-  });
-});
-
-describe('Allure reporter - Helper Functions', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+      expect(mockGroupStartTest).not.toHaveBeenCalled();
+    });
   });
 
-  it('Should add screenshots to an ended test without steps', () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+  describe('Test Processing', () => {
+    it('Should end passing test with no steps', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testRunInfo: TestRunInfo = {};
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+      // @ts-ignore
+      reporter.addScreenshotAttachments = mockReporterAddScreenshotAttachments;
 
-    const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
-    const testScreenshotOnFail: Screenshot = { screenshotPath: 'testPathOnFail', takenOnFail: true };
-    const testScreenshots: Screenshot[] = [testScreenshotManual, testScreenshotOnFail];
-    const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
-    const reporter: AllureReporter = new AllureReporter();
-    // @ts-ignore
-    reporter.addScreenshotAttachments(mockAllureTest, testRunInfo);
+      reporter.endTest(testName, testRunInfo, testMeta);
 
-    expect(mockTestAddAttachment).toBeCalledTimes(2);
-    expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken manually', ContentType.PNG, 'filename.png');
-    expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken on fail', ContentType.PNG, 'filename.png');
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(Metadata).toHaveBeenCalledTimes(1);
+      expect(Metadata).toBeCalledWith(testMeta, true);
+      expect(mockAddMetadataToTest).toHaveBeenCalledTimes(1);
+      expect(mockGetSteps).toBeCalledTimes(1);
+      expect(mockReporterAddScreenshotAttachments).toBeCalledTimes(1);
+
+      expect(mockAllureTest.status).toBe(Status.PASSED);
+      expect(mockAllureTest.detailsMessage).toBe('');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should end passing test with steps', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testRunInfo: TestRunInfo = {};
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+      // @ts-ignore
+      reporter.addStepsWithAttachments = mockReporterAddStepsWithAttachments;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(Metadata).toHaveBeenCalledTimes(1);
+      expect(Metadata).toBeCalledWith(testMeta, true);
+      expect(mockAddMetadataToTest).toHaveBeenCalledTimes(1);
+      expect(mockGetSteps).toBeCalledTimes(1);
+      expect(mockReporterAddStepsWithAttachments).toBeCalledTimes(1);
+
+      expect(mockAllureTest.status).toBe(Status.PASSED);
+      expect(mockAllureTest.detailsMessage).toBe('');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should end skipped test', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testRunInfo: TestRunInfo = { skipped: true };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(mockAllureTest.status).toBe(Status.SKIPPED);
+      expect(mockAllureTest.detailsMessage).toBe('');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should add warnings to ended test', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testWarnings: string[] = ['warning1', 'warning2'];
+      const testRunInfo: TestRunInfo = { warnings: testWarnings };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(mockAllureTest.status).toBe(Status.PASSED);
+      expect(mockAllureTest.detailsMessage).toEqual('warning1\nwarning2');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should add errors to ended test', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testError: any = {
+        callsite: {
+          filename: 'testFilename',
+          lineNum: 'testLineNum',
+        },
+        userAgent: 'testUserAgent',
+        errMsg: 'testErrorMessage',
+      };
+      const testErrors: any[] = [testError];
+      const testRunInfo: TestRunInfo = { errs: testErrors };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(mockAllureTest.status).toBe(Status.FAILED);
+      expect(mockAllureTest.detailsMessage).toBe(testError.errMsg);
+      expect(mockAllureTest.detailsTrace).toBe(
+        `File name: ${testError.callsite.filename}\nLine number: ${testError.callsite.lineNum}\nUser Agent(s): ${testError.userAgent}`,
+      );
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should not add empty errors to ended test', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testError: any = { callsite: {} };
+      const testErrors: any[] = [testError];
+      const testRunInfo: TestRunInfo = { errs: testErrors };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(mockAllureTest.status).toBe(Status.FAILED);
+      expect(mockAllureTest.detailsMessage).toBe('');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should not add empty callsite errors to ended test', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testError: any = {};
+      const testErrors: any[] = [testError];
+      const testRunInfo: TestRunInfo = { errs: testErrors };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestExists;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestExists).toBeCalledTimes(1);
+      expect(mockAllureTest.status).toBe(Status.FAILED);
+      expect(mockAllureTest.detailsMessage).toBe('');
+      expect(mockAllureTest.detailsTrace).toBe('');
+      expect(mockAllureTest.stage).toBe(Stage.FINISHED);
+      expect(mockTestEndTest).toBeCalledTimes(1);
+    });
+
+    it('Should start new test if non-existing test is ended', () => {
+      const testName: string = 'testname';
+      const testMeta: object = { severity: Severity.TRIVIAL };
+      const testRunInfo: TestRunInfo = {};
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.getCurrentTest = mockReporterGetCurrentTestNull;
+      // @ts-ignore
+      reporter.startTest = mockReporterStartTest;
+
+      reporter.endTest(testName, testRunInfo, testMeta);
+
+      expect(mockReporterGetCurrentTestNull).toBeCalledTimes(2);
+      expect(mockReporterStartTest).toBeCalledTimes(1);
+      expect(mockReporterStartTest).toBeCalledWith(testName, testMeta);
+    });
   });
-  it('Should add screenshots to an ended test with steps', () => {
-    const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
-    const testScreenshotOnFail: Screenshot = { screenshotPath: 'testPathOnFail', takenOnFail: true };
-    const testScreenshots: Screenshot[] = [testScreenshotManual, testScreenshotOnFail];
-    const testStepSuccess: TestStep = new TestStep('testStepSuccesfull');
-    const testStepFailed: TestStep = new TestStep('testStepFailed');
-    const testSteps: TestStep[] = [testStepSuccess, testStepFailed];
-    const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
-    const reporter: AllureReporter = new AllureReporter();
 
-    // @ts-ignore
-    reporter.mergeSteps = mockMergeSteps;
-    // @ts-ignore
-    reporter.addScreenshotAttachment = mockReporterAddScreenshotAttachment;
+  describe('Helper Functions', () => {
+    it('Should add screenshots to an ended test without steps', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      jest.spyOn(fs, 'readFileSync').mockReturnValue('');
 
-    // @ts-ignore
-    reporter.addStepsWithAttachments(mockAllureTest, testRunInfo, testSteps);
+      const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
+      const testScreenshotOnFail: Screenshot = { screenshotPath: 'testPathOnFail', takenOnFail: true };
+      const testScreenshots: Screenshot[] = [testScreenshotManual, testScreenshotOnFail];
+      const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
+      const reporter: AllureReporter = new AllureReporter();
+      // @ts-ignore
+      reporter.addScreenshotAttachments(mockAllureTest, testRunInfo);
 
-    expect(mockTestStartStep).toBeCalledTimes(2);
-    expect(mockTestStartStep).toBeCalledWith(testStepSuccess.name);
-    expect(mockTestStartStep).toBeCalledWith(testStepFailed.name);
+      expect(mockTestAddAttachment).toBeCalledTimes(2);
+      expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken manually', ContentType.PNG, 'filename.png');
+      expect(mockTestAddAttachment).toBeCalledWith('Screenshot taken on fail', ContentType.PNG, 'filename.png');
+    });
 
-    expect(mockMergeSteps).toBeCalledTimes(1);
-    expect(mockReporterAddScreenshotAttachment).toBeCalledTimes(2);
-  });
-  it('Should not add screenshots to steps if testStep screenshotAmount is not > 0', () => {
-    const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
-    const testScreenshots: Screenshot[] = [testScreenshotManual];
-    const testStepSuccess: TestStep = new TestStep('testStepSuccesfull');
-    testStepSuccess.screenshotAmount = 0;
-    const testSteps: TestStep[] = [testStepSuccess];
-    const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
-    const reporter: AllureReporter = new AllureReporter();
+    it('Should add screenshots to an ended test with steps', () => {
+      const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
+      const testScreenshotOnFail: Screenshot = { screenshotPath: 'testPathOnFail', takenOnFail: true };
+      const testScreenshots: Screenshot[] = [testScreenshotManual, testScreenshotOnFail];
+      const testStepSuccess: TestStep = new TestStep('testStepSuccesfull');
+      const testStepFailed: TestStep = new TestStep('testStepFailed');
+      const testSteps: TestStep[] = [testStepSuccess, testStepFailed];
+      const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
+      const reporter: AllureReporter = new AllureReporter();
 
-    // @ts-ignore
-    reporter.mergeSteps = mockMergeSteps;
-    // @ts-ignore
-    reporter.addScreenshotAttachment = mockReporterAddScreenshotAttachment;
+      // @ts-ignore
+      reporter.mergeSteps = mockMergeSteps;
+      // @ts-ignore
+      reporter.addScreenshotAttachment = mockReporterAddScreenshotAttachment;
 
-    // @ts-ignore
-    reporter.addStepsWithAttachments(mockAllureTest, testRunInfo, testSteps);
+      // @ts-ignore
+      reporter.addStepsWithAttachments(mockAllureTest, testRunInfo, testSteps);
 
-    expect(mockTestStartStep).toBeCalledTimes(1);
-    expect(mockTestStartStep).toBeCalledWith(testStepSuccess.name);
+      expect(mockTestStartStep).toBeCalledTimes(2);
+      expect(mockTestStartStep).toBeCalledWith(testStepSuccess.name);
+      expect(mockTestStartStep).toBeCalledWith(testStepFailed.name);
 
-    expect(mockMergeSteps).toBeCalledTimes(1);
-    expect(mockReporterAddScreenshotAttachment).not.toBeCalled();
-  });
-  it('Should not add screenshot if path is null', () => {
-    const testScreenshotManual: Screenshot = { screenshotPath: null, takenOnFail: false };
-    const reporter: AllureReporter = new AllureReporter();
+      expect(mockMergeSteps).toBeCalledTimes(1);
+      expect(mockReporterAddScreenshotAttachment).toBeCalledTimes(2);
+    });
 
-    // @ts-ignore
-    reporter.addScreenshotAttachment(mockAllureTest, testScreenshotManual);
+    it('Should not add screenshots to steps if testStep screenshotAmount is not > 0', () => {
+      const testScreenshotManual: Screenshot = { screenshotPath: 'testPathOnManual', takenOnFail: false };
+      const testScreenshots: Screenshot[] = [testScreenshotManual];
+      const testStepSuccess: TestStep = new TestStep('testStepSuccesfull');
+      testStepSuccess.screenshotAmount = 0;
+      const testSteps: TestStep[] = [testStepSuccess];
+      const testRunInfo: TestRunInfo = { screenshots: testScreenshots };
+      const reporter: AllureReporter = new AllureReporter();
 
-    expect(mockTestAddAttachment).not.toBeCalled();
-  });
-  it('Should set and get current test', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const test: AllureTest = new AllureTest(null);
-    const testName: string = 'test';
-    // @ts-ignore
-    reporter.setCurrentTest(testName, test);
+      // @ts-ignore
+      reporter.mergeSteps = mockMergeSteps;
+      // @ts-ignore
+      reporter.addScreenshotAttachment = mockReporterAddScreenshotAttachment;
 
-    // @ts-ignore
-    expect(reporter.getCurrentTest(testName)).toBe(test);
-  });
-  it('Should return null if test could not be found', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const testName: string = 'test';
+      // @ts-ignore
+      reporter.addStepsWithAttachments(mockAllureTest, testRunInfo, testSteps);
 
-    // @ts-ignore
-    expect(reporter.getCurrentTest(testName)).toBe(null);
-  });
-  it('Should return null if testName is null', () => {
-    const reporter: AllureReporter = new AllureReporter();
-    const testName: string = null;
+      expect(mockTestStartStep).toBeCalledTimes(1);
+      expect(mockTestStartStep).toBeCalledWith(testStepSuccess.name);
 
-    // @ts-ignore
-    expect(reporter.getCurrentTest(testName)).toBe(null);
+      expect(mockMergeSteps).toBeCalledTimes(1);
+      expect(mockReporterAddScreenshotAttachment).not.toBeCalled();
+    });
+
+    it('Should not add screenshot if path is null', () => {
+      const testScreenshotManual: Screenshot = { screenshotPath: null, takenOnFail: false };
+      const reporter: AllureReporter = new AllureReporter();
+
+      // @ts-ignore
+      reporter.addScreenshotAttachment(mockAllureTest, testScreenshotManual);
+
+      expect(mockTestAddAttachment).not.toBeCalled();
+    });
+
+    it('Should set and get current test', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const test: AllureTest = new AllureTest(null);
+      const testName: string = 'test';
+      // @ts-ignore
+      reporter.setCurrentTest(testName, test);
+
+      // @ts-ignore
+      expect(reporter.getCurrentTest(testName)).toBe(test);
+    });
+
+    it('Should return null if test could not be found', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const testName: string = 'test';
+
+      // @ts-ignore
+      expect(reporter.getCurrentTest(testName)).toBe(null);
+    });
+
+    it('Should return null if testName is null', () => {
+      const reporter: AllureReporter = new AllureReporter();
+      const testName: string = null;
+
+      // @ts-ignore
+      expect(reporter.getCurrentTest(testName)).toBe(null);
+    });
   });
 });


### PR DESCRIPTION
endTest's detailsMessage and detailsTrace value should be an empty string in favor of a value of null.

Closes #45 