### PR TITLE
feat(metadata): Implement default labels 'framework' and 'language'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To ensure a smooth code review and merging process please check if the Pull Requ
 - The GitHub Action pipeline concludes successfully:
   - The code follows the style guide used within this project. This can be tested locally by running: `npm run test:lint`.
   - The code passes all unit tests. This can be tested locally by running: `npm run test:unit`.
-- The change does not break the example e2e tests. This can be tested locally by running `npm run test:e2e`. After running e2e tests, `allure` directory will have `allure-restults` that can be used to see example allure report. Please run `npm run allure` and check how final report will look like
+- The change does not break the example e2e tests. This can be tested locally by running `npm run test:e2e`. After running e2e tests, `allure` directory will have `allure-results` that can be used to see example allure report. Please run `npm run allure` and check how final report will look like
 - The change pass integration tests that should be run only after e2e tests passed. This can be tested locally by running `npm run test:e2e`, then after e2e finished run `npm run test:integration`
 
 You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ To ensure a smooth code review and merging process please check if the Pull Requ
 - The GitHub Action pipeline concludes successfully:
   - The code follows the style guide used within this project. This can be tested locally by running: `npm run test:lint`.
   - The code passes all unit tests. This can be tested locally by running: `npm run test:unit`.
-- The change does not break the example e2e tests. This can be tested locally by running `npm run test:e2e:allure`.
+- The change does not break the example e2e tests. This can be tested locally by running `npm run test:e2e`. After running e2e tests, `allure` directory will have `allure-restults` that can be used to see example allure report. Please run `npm run allure` and check how final report will look like
+- The change pass integration tests that should be run only after e2e tests passed. This can be tested locally by running `npm run test:e2e`, then after e2e finished run `npm run test:integration`
 
 You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.

--- a/src/reporter/metadata.ts
+++ b/src/reporter/metadata.ts
@@ -87,6 +87,10 @@ export default class Metadata {
     // Labels only accept specific keys/names as valid, it will ignore all other labels
     // Other variabels have to be added as parameters or links.
 
+    // Add default labels for language and framework that could be used by other libraries that parse allure results
+    test.addLabel('framework', 'TestCafe');
+    test.addLabel('language', 'typescript/javascript');
+
     // Only the first severity value is loaded.
     if (this.severity) {
       test.addLabel(LabelName.SEVERITY, this.severity);

--- a/tests/integration/__snapshots__/allure.test.ts.snap
+++ b/tests/integration/__snapshots__/allure.test.ts.snap
@@ -13,6 +13,14 @@ Array [
     "fullName": "All Failed Fixture : Failed Test 1 Incorrect Assert",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -66,6 +74,14 @@ Array [
     "description": undefined,
     "fullName": "All Failed Fixture : Failed Test 2",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -121,6 +137,14 @@ Array [
     "fullName": "All Failed Fixture : Failed Test 3 No ",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -174,6 +198,14 @@ Array [
     "description": undefined,
     "fullName": "All Failed Fixture : Failed Test 4 Error Thrown",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -253,6 +285,14 @@ Array [
     "fullName": "All Failed Fixture : Failed Test 4 Selector DNE with 2 screenshots",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -307,6 +347,14 @@ Array [
     "fullName": "All Failed Fixture : Failed Test 5 Selector Click DNE",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -356,6 +404,14 @@ Array [
     "fullName": "All Skipped Fixture : Skipped Test 0",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -404,6 +460,14 @@ Array [
     "description": undefined,
     "fullName": "All Skipped Fixture : Skipped Test 1",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -459,6 +523,14 @@ Array [
     "fullName": "Failing Assert Fixture : FAF Test",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -512,6 +584,14 @@ Array [
     "description": undefined,
     "fullName": "Failing Fixture Setup : FF Test",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -567,6 +647,14 @@ Array [
     "fullName": "Mixed Fixture : MF Failed Test Selector DNE",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -616,6 +704,14 @@ Array [
     "fullName": "Mixed Fixture : MF Skipped Test",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -664,6 +760,14 @@ Array [
     "description": "Checks something foo",
     "fullName": "Mixed Fixture : Pass/Fail Test With ALL META 0",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "critical",
@@ -723,6 +827,14 @@ Array [
     "fullName": "Mixed Fixture : Pass/Fail Test With ALL META 1",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "critical",
       },
@@ -781,6 +893,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Flaky Tests : Actual flaky test example",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -824,6 +944,14 @@ Array [
     "description": undefined,
     "fullName": "TestCafé Example Fixture - Flaky Tests : Manual flaky test example",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -873,6 +1001,14 @@ Array [
     "description": undefined,
     "fullName": "TestCafé Example Fixture - Main : Example failing e2e test with steps",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "Normal",
@@ -927,6 +1063,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Main : Example failing e2e test without steps",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -975,6 +1119,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Main : Example skipped test",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -1022,6 +1174,14 @@ Array [
     "description": "An example discription",
     "fullName": "TestCafé Example Fixture - Main : Example test with all metadata",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "trivial",
@@ -1090,6 +1250,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Main : Example test with minimal metadata",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "Normal",
       },
@@ -1138,6 +1306,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Meta Overrides : Example severity metadata override BLOCKER",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "blocker",
       },
@@ -1178,6 +1354,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Meta Overrides : Example severity metadata override MINOR",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "minor",
       },
@@ -1217,6 +1401,14 @@ Array [
     "description": "Checks something else",
     "fullName": "TestCafé Example Fixture - Meta Overrides : Passing Test 0",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "critical",
@@ -1283,6 +1475,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Meta Overrides : Passing Test 1",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "critical",
       },
@@ -1348,6 +1548,14 @@ Array [
     "fullName": "TestCafé Example Fixture - Meta Overrides : Passing Test With ALL META 0",
     "labels": Array [
       Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
+      Object {
         "name": "severity",
         "value": "critical",
       },
@@ -1400,6 +1608,14 @@ Array [
     "description": "Checks something",
     "fullName": "TestCafé Example Fixture - Meta Overrides : Passing Test With ALL META 1",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "critical",
@@ -1462,6 +1678,14 @@ Array [
     "description": undefined,
     "fullName": "TestCafé Example Fixture - Meta Overrides : Passing Test with 2 screenshots",
     "labels": Array [
+      Object {
+        "name": "framework",
+        "value": "TestCafe",
+      },
+      Object {
+        "name": "language",
+        "value": "typescript/javascript",
+      },
       Object {
         "name": "severity",
         "value": "critical",

--- a/tests/unit/reporter/metadata.spec.ts
+++ b/tests/unit/reporter/metadata.spec.ts
@@ -204,7 +204,7 @@ describe('Metadata merging', () => {
     expect(localMetaData.parent_suite).toBe(groupMeta.suite);
 
     expect(mockAddParameter).toHaveBeenCalledTimes(1);
-    expect(mockAddLabel).toHaveBeenCalledTimes(7);
+    expect(mockAddLabel).toHaveBeenCalledTimes(9);
     expect(mockAddLink).toHaveBeenCalledTimes(1);
   });
   it('Should use group metadata if local is missing them', () => {
@@ -239,7 +239,7 @@ describe('Metadata merging', () => {
     expect(localMetaData.parent_suite).toBe(groupMeta.suite);
 
     expect(mockAddParameter).toHaveBeenCalledTimes(1);
-    expect(mockAddLabel).toHaveBeenCalledTimes(6); // One less than above test because sub_suite is not defined
+    expect(mockAddLabel).toHaveBeenCalledTimes(8); // One less than above test because sub_suite is not defined
     expect(mockAddLink).toHaveBeenCalledTimes(1);
   });
   it('Should only add metadata if it is defined', () => {
@@ -251,7 +251,7 @@ describe('Metadata merging', () => {
 
     // No calls to AllureTest functions have been made if there is no metadata, execept for a default severity label.
     expect(mockAddParameter).toHaveBeenCalledTimes(0);
-    expect(mockAddLabel).toHaveBeenCalledTimes(1);
+    expect(mockAddLabel).toHaveBeenCalledTimes(3);
     expect(mockAddLink).toHaveBeenCalledTimes(0);
   });
   it('Should validate if the groupMetadata object is valid', () => {

--- a/tests/unit/result/test-content.spec.ts
+++ b/tests/unit/result/test-content.spec.ts
@@ -1,4 +1,4 @@
-import { InMemoryAllureWriter, LinkType, Severity, Stage, Status } from 'allure-js-commons';
+import { InMemoryAllureWriter, LinkType, Severity, Stage, Status, LabelName } from 'allure-js-commons';
 import { createObjectReport } from '../../utils/create-report';
 import '../../utils/jest-enum-matcher';
 
@@ -53,8 +53,11 @@ describe('Test results', () => {
   it('Should contain a specific severity', () => {
     const report: InMemoryAllureWriter = createObjectReport();
 
-    const label = report.tests[0].labels[0];
-    expect(label.value).toBe(Severity.BLOCKER);
+    const testLabels = report.tests[0].labels;
+    const severityLabel = testLabels.filter((label) => {
+      return label.name === LabelName.SEVERITY;
+    });
+    expect(severityLabel[0].value).toBe(Severity.BLOCKER);
   });
   it('Should contain a specific link', () => {
     const report: InMemoryAllureWriter = createObjectReport();


### PR DESCRIPTION
Hi to library contributors and maintenance,
Thank you very much for writing really nicely organized and tested typescript library and thank you for detailed `CONTRIBUTING.md` file.

**Objectives for this change**
Our team uses variety of different frameworks and they all use allure reporting. We want to index which test results are coming from which framework and all extensions that we use with allure (junit4, junit5, cypress, pytest) are adding 'framework' and 'language' into `the labels` array. Without it in TestCafe, our TestCafe tests are not indexed.

Example of how allure report looks like in junit5 allure extension:
```
{
  "attachments": [],
  "description": "",
  "fullName": "com.indeed.test.FooJUnit5Test.testPassedRetriedThreeTimes",
  "historyId": "1412e1206ef3da2fe04e10a6624ebaa8",
  "labels": [
    {
      "name": "host",
      "value": "XXXX"
    },
    {
      "name": "thread",
      "value": "59625@XXXXX.Test worker(12)"
    },
    {
      "name": "framework",
      "value": "junit-platform"
    },
    {
      "name": "language",
      "value": "java"
    },
    {
      "name": "package",
      "value": "com.indeed.test.FooJUnit5Test"
    },
    {
      "name": "testClass",
      "value": "com.indeed.test.FooJUnit5Test"
    },
    {
      "name": "testMethod",
      "value": "testPassedRetriedThreeTimes"
    },
    {
      "name": "suite",
      "value": "com.indeed.test.FooJUnit5Test"
    }
  ],
  "links": [],
  "name": "testPassedRetriedThreeTimes() (Repetition 3 of 3)",
  "parameters": [],
  "stage": "finished",
  "start": 1610591701664,
  "status": "skipped",
  "statusDetails": {
    "flaky": false,
    "known": false,
    "message": "Turn off the remaining repetitions as the test ultimately passed",
    "muted": false
  },
  "steps": [],
  "stop": 1610591701664,
  "uuid": "068b156d-df1b-460d-914e-85b2e2fc53da"
}
```

Example of current `testcafe-reporter-allure` report: 

```
{
    "uuid": "bf1d235f-a415-46f6-9f47-e5c4a45e6e34",
    "historyId": "f68ffef2-b7cc-442a-af80-0e2b4df2fffc",
    "status": "passed",
    "statusDetails": { "message": "", "trace": "" },
    "stage": "finished",
    "steps": [],
    "attachments": [],
    "parameters": [
        { "name": "accessibility", "value": "true" },
        { "name": "functional", "value": "false" },
    ],
    "labels": [
        { "name": "severity", "value": "Normal" },
        { "name": "suite", "value": "suite name" }
    ],
    "links": [],
    "start": 1625561608968,
    "name": "test",
    "fullName": "test",
    "stop": 1625561664345
}
```

I have reviewed `pytest` allure extension and it also produces `labels` with `framework` and `language`: 
```
"labels": [
    {
      "name": "parentSuite",
      "value": "tests"
    },
    {
      "name": "suite",
      "value": "test_example"
    },
    {
      "name": "subSuite",
      "value": "TestCase"
    },
    {
      "name": "host",
      "value": "IT-USA-VX0119"
    },
    {
      "name": "thread",
      "value": "17359-MainThread"
    },
    {
      "name": "framework",
      "value": "pytest"
    },
    {
      "name": "language",
      "value": "cpython3"
    },
    {
      "name": "package",
      "value": "tests.test_example"
    }
  ],
```

**Summary of changes**

-  Added two labels: `framework` and `languages` that will be always added to every test result
- Updated tests
- Updated `CONTRIBUTING.md` file