### PR TITLE
fix: temporary lock allure-js-commons to 2.0.0-beta.8 without TypeError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12438,7 +12438,8 @@
     },
     "glob-parent": {
       "version": "5.1.1",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "allure-js-commons": "^2.0.0-beta.8",
+    "allure-js-commons": "2.0.0-beta.8",
     "lodash": "^4.17.21",
     "rimraf": "^3.0.2",
     "uuid": "^8.3.2"


### PR DESCRIPTION
We started to get an error "TypeError: allureJsCommons.AllureConfig is not a constructor" that fails our builds.

Until the issue is fixed in [allure-framework/allure-js-commons](https://github.com/allure-framework/allure-js-commons/issues/48) I would like to propose this temporary solution to lock on `"allure-js-commons": "2.0.0-beta.8"` that is still backward compatible.

Removing `^` should lock npm on specific version, while using "^2.0.0-beta.8" currently install minor versions that incompatible with current implementation of `testcafe-reporter-allure`.

The error is also reported in #102.