### PR TITLE
fix(reporter): check if screenshot object is defined

### DIFF
--- a/src/reporter/allure-reporter.ts
+++ b/src/reporter/allure-reporter.ts
@@ -210,7 +210,7 @@ export default class AllureReporter {
   }
 
   private addScreenshotAttachment(test: ExecutableItemWrapper, screenshot: Screenshot): void {
-    if (screenshot.screenshotPath && fs.existsSync(screenshot.screenshotPath)) {
+    if (screenshot && screenshot.screenshotPath && fs.existsSync(screenshot.screenshotPath)) {
       let screenshotName: string;
       if (screenshot.takenOnFail) {
         screenshotName = reporterConfig.LABEL.SCREENSHOT_ON_FAIL;

--- a/tests/unit/reporter/allure-reporter.spec.ts
+++ b/tests/unit/reporter/allure-reporter.spec.ts
@@ -527,6 +527,16 @@ describe('Allure reporter', () => {
       expect(mockTestAddAttachment).not.toBeCalled();
     });
 
+    it('Should not add screenshot if object is undefined', () => {
+      const testScreenshotManual: Screenshot = undefined;
+      const reporter: AllureReporter = new AllureReporter();
+
+      // @ts-ignore
+      reporter.addScreenshotAttachment(mockAllureTest, testScreenshotManual);
+
+      expect(mockTestAddAttachment).not.toBeCalled();
+    });
+
     it('Should set and get current test', () => {
       const reporter: AllureReporter = new AllureReporter();
       const test: AllureTest = new AllureTest(null);


### PR DESCRIPTION
Added additional check to skip calling attach Screenshot method if `screenshot` object is undefined.